### PR TITLE
Enhance AttributeUsage DSL rendering

### DIFF
--- a/backend/src/main/java/com/sysml/lightmodel/dsl/AttributeUsageDslRenderer.java
+++ b/backend/src/main/java/com/sysml/lightmodel/dsl/AttributeUsageDslRenderer.java
@@ -3,6 +3,10 @@ package com.sysml.lightmodel.dsl;
 import com.sysml.lightmodel.semantic.DslRenderUtils;
 import com.sysml.lightmodel.semantic.Element;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 public class AttributeUsageDslRenderer implements DslRenderer {
     @Override
     public String render(Element element, int indent) {
@@ -19,14 +23,69 @@ public class AttributeUsageDslRenderer implements DslRenderer {
             typeStr = "null";
         }
 
+        Map<String, Object> metadata = element.getMetadata();
+        String direction = extractMetadataValue(metadata, "direction");
+        String multiplicity = formatMultiplicity(extractMetadataValue(metadata, "multiplicity"));
+        String defaultValue = extractMetadataValue(metadata, "defaultValue");
+
         sb.append(indentStr)
-                .append("attr ").append(element.getName())
-                .append(": ").append(typeStr)
-                .append(DslRenderHelper.renderMultiplicity(element))
-                .append(DslRenderHelper.renderMetadata(element))
-                .append(DslRenderHelper.renderDocumentation(element))
+                .append("attr ");
+        if (direction != null && !direction.isBlank()) {
+            sb.append("«").append(direction).append("» ");
+        }
+        sb.append(element.getName())
+                .append(": ").append(typeStr);
+
+        if (!multiplicity.isEmpty()) {
+            sb.append(multiplicity);
+        }
+        if (defaultValue != null && !defaultValue.isBlank()) {
+            sb.append(" = ").append(defaultValue);
+        }
+
+        String metadataStr = DslRenderHelper.renderMetadata(element,
+                Set.of("multiplicity", "defaultValue", "direction"));
+        if (!metadataStr.isEmpty()) {
+            if (defaultValue != null && !defaultValue.isBlank()) {
+                sb.append(' ');
+            }
+            sb.append(metadataStr);
+        }
+
+        sb.append(DslRenderHelper.renderDocumentation(element))
                 .append("\n");
         return sb.toString();
+    }
+
+    private String extractMetadataValue(Map<String, Object> metadata, String key) {
+        if (metadata == null || key == null) {
+            return null;
+        }
+        Object value = metadata.get(key);
+        return value != null ? Objects.toString(value) : null;
+    }
+
+    private String formatMultiplicity(String rawMultiplicity) {
+        if (rawMultiplicity == null || rawMultiplicity.isBlank()) {
+            return "";
+        }
+        String multiplicity = rawMultiplicity.trim();
+        if (multiplicity.startsWith("[") && multiplicity.endsWith("]") && multiplicity.length() > 2) {
+            multiplicity = multiplicity.substring(1, multiplicity.length() - 1).trim();
+        }
+        multiplicity = multiplicity.replaceAll("\\s+", "");
+        if ("1..1".equals(multiplicity)) {
+            return "";
+        }
+        if (multiplicity.contains("..")) {
+            String[] parts = multiplicity.split("\\.\\.", -1);
+            if (parts.length == 2) {
+                String lower = parts[0].isEmpty() ? "1" : parts[0];
+                String upper = parts[1].isEmpty() ? "*" : parts[1];
+                multiplicity = lower + ".." + upper;
+            }
+        }
+        return "[" + multiplicity + "]";
     }
 }
 

--- a/backend/src/main/java/com/sysml/lightmodel/dsl/DslRenderHelper.java
+++ b/backend/src/main/java/com/sysml/lightmodel/dsl/DslRenderHelper.java
@@ -12,11 +12,16 @@ public class DslRenderHelper {
     }
 
     public static String renderMetadata(Element element) {
+        return renderMetadata(element, Set.of("multiplicity"));
+    }
+
+    public static String renderMetadata(Element element, Set<String> excludedKeys) {
         Map<String, Object> metadata = element.getMetadata();
         if (metadata == null || metadata.isEmpty()) return "";
+        Set<String> exclusions = excludedKeys != null ? excludedKeys : Collections.emptySet();
         List<String> entries = new ArrayList<>();
         for (var e : metadata.entrySet()) {
-            if ("multiplicity".equals(e.getKey())) continue;
+            if (exclusions.contains(e.getKey())) continue;
             entries.add(e.getKey() + " = \"" + e.getValue() + "\"");
         }
         return entries.isEmpty() ? "" : "{ " + String.join(", ", entries) + " }";

--- a/backend/src/test/java/com/sysml/lightmodel/dsl/AttributeUsageDslRendererTest.java
+++ b/backend/src/test/java/com/sysml/lightmodel/dsl/AttributeUsageDslRendererTest.java
@@ -1,0 +1,47 @@
+package com.sysml.lightmodel.dsl;
+
+import com.sysml.lightmodel.semantic.Element;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AttributeUsageDslRendererTest {
+
+    @Test
+    void rendersDirectionDefaultAndMultiplicity() {
+        Element element = new Element();
+        element.setName("speed");
+        element.setDefinitionName("Real");
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("direction", "in");
+        metadata.put("multiplicity", "0..*");
+        metadata.put("defaultValue", "3.14");
+        metadata.put("unit", "mps");
+        element.setMetadata(metadata);
+
+        String rendered = new AttributeUsageDslRenderer().render(element, 0);
+
+        assertEquals("attr «in» speed: Real[0..*] = 3.14 { unit = \"mps\" }\n", rendered);
+    }
+
+    @Test
+    void omitsDefaultMultiplicityWhenSingleCardinality() {
+        Element element = new Element();
+        element.setName("count");
+        element.setDefinitionName("Integer");
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("direction", "out");
+        metadata.put("multiplicity", "1..1");
+        metadata.put("defaultValue", "42");
+        element.setMetadata(metadata);
+
+        String rendered = new AttributeUsageDslRenderer().render(element, 0);
+
+        assertEquals("attr «out» count: Integer = 42\n", rendered);
+    }
+}


### PR DESCRIPTION
## Summary
- render AttributeUsage usages with direction, multiplicity normalization, and default values in the DSL exporter
- extend the DSL render helper to support excluding metadata keys from inline rendering
- cover the new AttributeUsage formatting logic with unit tests

## Testing
- `mvn -f backend/pom.xml test` *(fails: unable to resolve Maven dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbc917a2483289038c073d00ab588