### PR TITLE
test: move AttributeUsage metadata assertions to renderer; keep import unchanged

### DIFF
--- a/backend/src/test/java/com/sysml/lightmodel/DefaultDslImportServiceTest.java
+++ b/backend/src/test/java/com/sysml/lightmodel/DefaultDslImportServiceTest.java
@@ -120,8 +120,9 @@ class DefaultDslImportServiceTest {
         assertNotNull(controller, "Controller definition should be parsed");
         Usage gain = findUsage(controller, "gain");
 
-        assertEquals("0..1", gain.getMultiplicity(), "Multiplicity metadata should be captured");
-        assertEquals("42", gain.getDefaultValue(), "Default value metadata should be captured");
+        assertNotNull(gain.getMetadata(), "Usage metadata should be present");
+        assertEquals("0..1", gain.getMetadata().get("multiplicity"), "Multiplicity metadata should be captured");
+        assertEquals("42", gain.getMetadata().get("defaultValue"), "Default value metadata should be captured");
     }
 
     @Test

--- a/backend/src/test/java/com/sysml/lightmodel/dsl/AttributeUsageDslRendererTest.java
+++ b/backend/src/test/java/com/sysml/lightmodel/dsl/AttributeUsageDslRendererTest.java
@@ -18,14 +18,14 @@ class AttributeUsageDslRendererTest {
 
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put("direction", "in");
-        metadata.put("multiplicity", "0..*");
-        metadata.put("defaultValue", "3.14");
+        metadata.put("multiplicity", "0..1");
+        metadata.put("defaultValue", "42");
         metadata.put("unit", "mps");
         element.setMetadata(metadata);
 
         String rendered = new AttributeUsageDslRenderer().render(element, 0);
 
-        assertEquals("attr «in» speed: Real[0..*] = 3.14 { unit = \"mps\" }\n", rendered);
+        assertEquals("attr «in» speed: Real[0..1] = 42 { unit = \"mps\" }\n", rendered);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update AttributeUsageDslRendererTest to assert direction, multiplicity, and default value are rendered for attribute usages
- adjust DefaultDslImportServiceTest to validate multiplicity and default value via metadata map rather than Usage accessors

## Testing
- `mvn -q -DskipITs clean test` *(fails: missing remote dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc2f61a3c8328984664a9d4ee0950