### PR TITLE
Guard ActionUsage renderer resolved definition access

### DIFF
--- a/backend/src/main/java/com/sysml/lightmodel/dsl/ActionUsageDslRenderer.java
+++ b/backend/src/main/java/com/sysml/lightmodel/dsl/ActionUsageDslRenderer.java
@@ -2,6 +2,7 @@ package com.sysml.lightmodel.dsl;
 
 import com.sysml.lightmodel.semantic.DslRenderUtils;
 import com.sysml.lightmodel.semantic.Element;
+import com.sysml.lightmodel.semantic.Usage;
 
 public class ActionUsageDslRenderer implements DslRenderer {
     @Override
@@ -11,8 +12,8 @@ public class ActionUsageDslRenderer implements DslRenderer {
         DslRenderUtils.appendDocumentation(sb, element, indentStr);
 
         String typeStr = element.getDefinitionName();
-        if (typeStr == null && element.getResolvedDefinition() != null) {
-            typeStr = element.getResolvedDefinition().getName();
+        if (typeStr == null && element instanceof Usage usage && usage.getResolvedDefinition() != null) {
+            typeStr = usage.getResolvedDefinition().getName();
         }
         if (typeStr == null) {
             typeStr = "null";


### PR DESCRIPTION
## Summary
- guard ActionUsage DSL rendering against non-Usage elements when resolving definitions
- import the Usage type required for the instanceof guard

## Testing
- `mvn -q -DskipTests compile` *(fails: repository download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc7bfbb948328bcd92a2c57380be9