### PR TITLE
Add transient definitionId to Usage

### DIFF
--- a/backend/src/main/java/com/sysml/lightmodel/semantic/Usage.java
+++ b/backend/src/main/java/com/sysml/lightmodel/semantic/Usage.java
@@ -1,6 +1,7 @@
 
 package com.sysml.lightmodel.semantic;
 
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,6 +14,9 @@ import lombok.EqualsAndHashCode;
 public class Usage extends Element {
 
     private String definitionName; // DSL 层：引用名，如 "Real", "Controller"
+
+    @TableField(exist = false)
+    private Long definitionId;
 
     private String type;
 


### PR DESCRIPTION
## Summary
- add a transient definitionId field to Usage so Lombok generates accessors
- annotate the new field with TableField(exist = false) to keep it non-persistent

## Testing
- ⚠️ `mvn -q -DskipTests package` *(fails: unable to reach Maven Central from container network)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc7c016508328b2beb196ad3c9d98