### PR TITLE
Fix constraint parsing and usage metadata handling

### DIFF
--- a/backend/src/main/java/com/sysml/lightmodel/dsl/parser/ConstraintUsageDslParser.java
+++ b/backend/src/main/java/com/sysml/lightmodel/dsl/parser/ConstraintUsageDslParser.java
@@ -1,12 +1,14 @@
 package com.sysml.lightmodel.dsl.parser;
 
 import com.sysml.lightmodel.semantic.ConstraintUsage;
+import com.sysml.lightmodel.semantic.Definition;
 import com.sysml.lightmodel.semantic.Element;
 import com.sysml.lightmodel.service.DefinitionBindingService;
 import com.sysml.lightmodel.utils.DslParseHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,7 +17,7 @@ public class ConstraintUsageDslParser implements DslParser {
 
     @Autowired
     private DefinitionBindingService definitionBindingService;
-    private static final Pattern MAIN_PATTERN = Pattern.compile("constraint\\s+(\\w+)\\s*:\\s*(\\w+)");
+    private static final Pattern MAIN_PATTERN = Pattern.compile("constraint\\s+(\\w+)\\s*:\\s*([\\w.]+)");
 
     @Override
     public Element parse(DslRawEntry entry) {
@@ -32,14 +34,22 @@ public class ConstraintUsageDslParser implements DslParser {
         ConstraintUsage usage = new ConstraintUsage();
         usage.setType("ConstraintUsage");
         usage.setName(name);
-        usage.setDefinitionName(type);
-        Element def = definitionBindingService.bind(type, "AttributeDefinition");
+
+        Element def = definitionBindingService.bind(type, "ConstraintDefinition");
         usage.setDefinitionId(def.getId());
         usage.setDefinitionName(def.getName());
-        usage.setResolvedDefinition(def);
+        if (def instanceof Definition definition) {
+            usage.setResolvedDefinition(definition);
+        }
 
-        // 加入 multiplicity
-        usage.setMetadata(DslParseHelper.enrichMetadata(line));
+        String expression = DslParseHelper.parseExpression(line);
+        usage.setExpression(expression);
+
+        Map<String, Object> metadata = DslParseHelper.enrichMetadata(line);
+        if (expression != null && !expression.isEmpty()) {
+            metadata.put("expr", expression);
+        }
+        usage.setMetadata(metadata);
         usage.setDocumentation(DslParseHelper.parseDocumentation(line));
 
         return usage;

--- a/backend/src/main/java/com/sysml/lightmodel/service/impl/DefaultDslImportService.java
+++ b/backend/src/main/java/com/sysml/lightmodel/service/impl/DefaultDslImportService.java
@@ -163,8 +163,16 @@ public class DefaultDslImportService implements DslImportService {
         usage.setName(node.getName());
         usage.setType(resolveUsageType(node.getKeyword()));
         usage.setDefinitionName(node.getDefinitionName());
-        usage.setMultiplicity(node.getMultiplicity());
-        usage.setDefaultValue(node.getDefaultValue());
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        if (node.getMultiplicity() != null) {
+            metadata.put("multiplicity", node.getMultiplicity());
+        }
+        if (node.getDefaultValue() != null) {
+            metadata.put("defaultValue", node.getDefaultValue());
+        }
+        if (!metadata.isEmpty()) {
+            usage.setMetadata(metadata);
+        }
         usage.setParentDefinition(owningDefinition);
         if (owner != null) {
             usage.setOwner(owner.getName());

--- a/backend/src/test/java/com/sysml/lightmodel/DefaultDslImportServiceTest.java
+++ b/backend/src/test/java/com/sysml/lightmodel/DefaultDslImportServiceTest.java
@@ -120,8 +120,9 @@ class DefaultDslImportServiceTest {
         assertNotNull(controller, "Controller definition should be parsed");
         Usage gain = findUsage(controller, "gain");
 
-        assertEquals("0..1", gain.getMultiplicity(), "Multiplicity metadata should be captured");
-        assertEquals("42", gain.getDefaultValue(), "Default value metadata should be captured");
+        assertNotNull(gain.getMetadata(), "Usage metadata should be initialized");
+        assertEquals("0..1", gain.getMetadata().get("multiplicity"), "Multiplicity metadata should be captured");
+        assertEquals("42", gain.getMetadata().get("defaultValue"), "Default value metadata should be captured");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update the constraint usage parser to bind constraint definitions, capture expressions, and record them in metadata
- persist multiplicity and default value information in usage metadata when importing DSL text
- ensure constraint usages only record a resolved definition when the binding result is a Definition instance

## Testing
- `mvn -q -Dtest=DefaultDslImportServiceTest test` *(fails: unable to resolve Maven dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cbce6a6f208328a464c7e940684f85